### PR TITLE
fix: prevent modal from closing when clicking outside

### DIFF
--- a/src/edit/StorePicker.js
+++ b/src/edit/StorePicker.js
@@ -48,6 +48,7 @@ const StorePicker = ({ onStoreSelect }, ref) => {
 
 	const modalProps = {
 		className: 'jf-store-picker-modal',
+		shouldCloseOnClickOutside: false
 	};
 
 	if (!isModalOpen) return null;


### PR DESCRIPTION
Ticket: https://www.jotform.com/answers/23161151-jotform-shopping-cart-wp-clicking-outside-the-modal-should-not-close-the-modal